### PR TITLE
Fix: Use single quotes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
 	classesAllowedToBeExtended:
 		- Faker\Provider\Base
 	ignoreErrors:
-		- "#Method .* has parameter .* with null as default value.#"
+		- '#Method .* has parameter .* with null as default value.#'
 	paths:
 		- src
 		- test


### PR DESCRIPTION
This PR

* [x] uses single quotes instead of double quotes for regular expressions in `ignoreErrors`