### PR TITLE
Fix: Avoid ignoring errors when running phpstan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,9 +11,6 @@ parameters:
 		- Faker\Provider\Base
 	ignoreErrors:
 		- '#Method .* has parameter .* with null as default value.#'
-		# https://github.com/phpstan/phpstan/issues/2141
-		- '#Method Localheinz\\Faker\\Provider\\Test\\Unit\\AvatarUrlProviderTest::createFakerWithAddedAvatarUrlProvider\(\) with return type void returns Faker\\Generator but should not return anything.#'
-		- '#PHPDoc tag @return contains unresolvable type.#'
 	paths:
 		- src
 		- test

--- a/test/Unit/AvatarUrlProviderTest.php
+++ b/test/Unit/AvatarUrlProviderTest.php
@@ -34,6 +34,7 @@ final class AvatarUrlProviderTest extends Framework\TestCase
      */
     public function testAdorableAvatarUrlRejectsInvalidIdentifier(string $identifier): void
     {
+        /** @var AvatarUrlProvider&Generator $faker */
         $faker = self::createFakerWithAddedAvatarUrlProvider();
 
         $size = $faker->numberBetween(200, 450);
@@ -79,6 +80,7 @@ final class AvatarUrlProviderTest extends Framework\TestCase
      */
     public function testAdorableAvatarUrlRejectsInvalidSize(int $size): void
     {
+        /** @var AvatarUrlProvider&Generator $faker */
         $faker = self::createFakerWithAddedAvatarUrlProvider();
 
         $identifier = $faker->userName;
@@ -97,6 +99,7 @@ final class AvatarUrlProviderTest extends Framework\TestCase
 
     public function testAdorableAvatarUrlReturnsAdorableAvatarUrlWhenInvokedWithoutArguments(): void
     {
+        /** @var AvatarUrlProvider&Generator $faker */
         $faker = self::createFakerWithAddedAvatarUrlProvider();
 
         $pattern = self::PATTERN_ADORABLE_AVATAR_URL;
@@ -106,6 +109,7 @@ final class AvatarUrlProviderTest extends Framework\TestCase
 
     public function testAdorableAvatarUrlReturnsAdorableAvatarUrlWithTrimmedIdentifier(): void
     {
+        /** @var AvatarUrlProvider&Generator $faker */
         $faker = self::createFakerWithAddedAvatarUrlProvider();
 
         $identifier = $faker->userName;
@@ -144,9 +148,6 @@ final class AvatarUrlProviderTest extends Framework\TestCase
         return $faker;
     }
 
-    /**
-     * @return AvatarUrlProvider&Generator
-     */
     private static function createFakerWithAddedAvatarUrlProvider(): Generator
     {
         $faker = self::createFaker();


### PR DESCRIPTION
This PR

* [x] works around ignoring errors when running `phpstan`

Related to https://github.com/phpstan/phpstan/issues/2141.